### PR TITLE
[fix]customerの配送先追加、更新が動かない問題を修正

### DIFF
--- a/app/views/public/addresses/edit.html.erb
+++ b/app/views/public/addresses/edit.html.erb
@@ -1,26 +1,26 @@
 <div class="container">
   <h2 class="text-center">配送先編集</h2>
   <div class="row mt-5">
-   <table class="mx-auto">
-    <tbody>
-      <%= form_with model: @address, url: address_path , method: :patch, local: true do |f| %>
-        <tr>
-          <td><%= f.label :"郵便番号(ハイフンなし)" %></td>
-          <td> <%= f.text_field :post_code ,class: "form-control"%></td>
-        </tr>
-        <tr>
-          <td><%= f.label :"住所" ,class: "col-xs-3" %></td>
-          <td> <%= f.text_field :address, class: "form-control" %></td>
-        </tr>
-        <tr>
-          <td> <%= f.label :"宛名" ,class: "col-xs-3" %></td>
-          <td><%= f.text_field :name, class: "form-control" %></td>
-        </tr>
-        <tr>
-          <td><%= f.submit '更新する',class: "btn btn-success mt-3 mb-5 d-block mx-auto" %></td>
-        </tr>
-      <% end %>
-   </tbody>
-    </table>
+    <%= form_with model: @address, url: address_path , method: :patch, local: true do |f| %>
+      <table class="mx-auto">
+        <tbody>
+          <tr>
+            <td><%= f.label :"郵便番号(ハイフンなし)" %></td>
+            <td> <%= f.text_field :post_code ,class: "form-control"%></td>
+          </tr>
+          <tr>
+            <td><%= f.label :"住所" ,class: "col-xs-3" %></td>
+            <td> <%= f.text_field :address, class: "form-control" %></td>
+          </tr>
+          <tr>
+            <td> <%= f.label :"宛名" ,class: "col-xs-3" %></td>
+            <td><%= f.text_field :name, class: "form-control" %></td>
+          </tr>
+          <tr>
+            <td><%= f.submit '更新する',class: "btn btn-success mt-3 mb-5 d-block mx-auto" %></td>
+          </tr>
+        </tbody>
+      </table>
+    <% end %>
   </div>
 </div>

--- a/app/views/public/addresses/index.html.erb
+++ b/app/views/public/addresses/index.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
  <h2 class="text-center">配送先登録/一覧</h2>
  <div class="row mt-5">
-   <table class="mx-auto">
-     <%= form_with model: @address, url: addresses_path, method: :post, local: true do |f| %>
+  <%= form_with model: @address, url: addresses_path, method: :post, local: true do |f| %>
+    <table class="mx-auto">
      <tr>
        <td><%= f.label :"郵便番号(ハイフンなし)"%></td>
        <td><%= f.text_field :post_code, class: "form-control" %></td>
@@ -18,8 +18,8 @@
       <tr>
         <td><%= f.submit '登録する' ,class: "btn btn-success mt-3 mb-5 d-block mx-auto" %></td>
       </tr>
-    <% end %>
    </table>
+  <% end %>
  </div>
 
 
@@ -33,7 +33,7 @@
           <th colspan="2"></th>
         </tr>
       </thead>
-  
+
       <tbody>
         <% @addresses.each do |address| %>
           <tr>


### PR DESCRIPTION
- tableタグとform_withは相性が悪い
- そのため、tableタグの外側にform_withを配置した